### PR TITLE
[BTR-3] fixed wrong datetime format for 10.17+

### DIFF
--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -29,6 +29,9 @@ import itertools
 import random
 import threading
 import time
+import pytz
+
+from tzlocal import get_localzone
 
 from ib.ext.Contract import Contract
 import ib.opt as ibopt
@@ -804,10 +807,18 @@ class IBStore(with_metaclass(MetaSingleton, object)):
         self.histsend[tickerId] = sessionend
         self.histtz[tickerId] = tz
 
+        #print(enddate)
+        #print(enddate.strftime('%Y%m%d %H:%M:%S') + ' GMT')
+        local_tz = get_localzone()
+        nytz = pytz.timezone("America/New_York")
+
+        nytime = enddate.astimezone(local_tz).astimezone(nytz)
+        #print(nytime)
+
         self.conn.reqHistoricalData(
             tickerId,
             contract,
-            bytes(enddate.strftime('%Y%m%d %H:%M:%S') + ' GMT'),
+            bytes(enddate.strftime('%Y%m%d %H:%M:%S') + ' US/Eastern'),
             bytes(duration),
             bytes(barsize),
             bytes(what),


### PR DESCRIPTION
Added fix for this problem https://community.backtrader.com/topic/6522/ib-market-data-subscriptions-end-date-time-the-date-time-or-time-zone-entered-is-invalid